### PR TITLE
Tests fail when the current environment doesn't use \n for new lines

### DIFF
--- a/tests/GovUk.Frontend.AspNetCore.Tests/Components/DefaultComponentGeneratorTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/Components/DefaultComponentGeneratorTests.cs
@@ -150,6 +150,9 @@ public class DefaultComponentGeneratorTests
                     return $"&#x{encodedDecimal:X};";
                 });
 
+        // Fixtures contain \n but the current environment may not use that
+        expectedHtml = expectedHtml.Replace("\n", Environment.NewLine);
+
         if (amendExpectedHtml is not null)
         {
             expectedHtml = amendExpectedHtml(expectedHtml);


### PR DESCRIPTION
I'm having a few difficulties getting your repo up-and-running locally on a Windows 11 machine. This solves one of them, where several tests fail because the fixtures contain `\n` but my environment is expecting `\r\n`.