### PR TITLE
Upgrade to govuk-frontend 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased — 5.0.0
 
+Targets GOV.UK Frontend v6.5.0.
+
+The content of `<govuk-service-navigation-end>` can be displayed in line with the navigation items, rather than underneath them, with the new `align` attribute:
+
+```razor
+<govuk-service-navigation service-name="My service">
+    <govuk-service-navigation-end align="Inline">
+        @* language navigation, account links etc. *@
+    </govuk-service-navigation-end>
+</govuk-service-navigation>
+```
+
+The language navigation and feedback components introduced in v6.5.0 do not have tag helpers yet.
+
 `_GovUkPageTemplate` no longer escapes its `<body>` and `<main>` elements, so tag helpers targeting them now run.
 
 The template wrote the attributes from the `BodyAttributes` and `MainAttributes` `ViewData` keys directly into the elements' attribute lists, which Razor only permits on an element that no tag helper targets — the elements had to be written as `<!body>` and `<!main>` to opt out. They're regular elements again and the attributes are applied by a tag helper.
@@ -314,6 +328,13 @@ A `string` assigned to an `Html` option is now HTML-encoded rather than emitted 
 Content that already came from Razor — anything assigned from a `TagHelperContent` or an `IHtmlContent` — is unaffected and still renders as markup.
 
 The `Text` and `Html` properties on `CharacterCountOptionsBeforeInput`, `CharacterCountOptionsAfterInput`, `FileUploadOptionsBeforeInput`, `FileUploadOptionsAfterInput`, `DateInputOptionsBeforeInputs` and `DateInputOptionsAfterInputs` are now `TemplateString?` rather than `string?`, matching every other component's before- and after-input options.
+
+`ServiceNavigationOptionsSlots.End` is now a `ServiceNavigationOptionsEndSlot?` rather than an `IHtmlContent?`, so that the slot can carry its alignment alongside its content:
+
+```diff
+-End = content
++End = new ServiceNavigationOptionsEndSlot { Html = content }
+```
 
 ## 4.4.0
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepoRoot>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepoRoot>
     <Nullable>enable</Nullable>
     <PackageOutputPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'packages'))</PackageOutputPath>
-    <GovUkFrontendVersion>6.4.0</GovUkFrontendVersion>
+    <GovUkFrontendVersion>6.5.0</GovUkFrontendVersion>
 
     <IsTestProject Condition="'$(IsTestProject)' == '' and $(MSBuildProjectName.EndsWith('Tests'))">true</IsTestProject>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOV.UK Frontend for ASP.NET Core
 
-[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-6.4.0-brightgreen)](https://github.com/alphagov/govuk-frontend/releases/tag/v6.4.0)
+[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-6.5.0-brightgreen)](https://github.com/alphagov/govuk-frontend/releases/tag/v6.5.0)
 [![Build](https://github.com/x-govuk/govuk-frontend-aspnetcore/actions/workflows/build.yml/badge.svg)](https://github.com/x-govuk/govuk-frontend-aspnetcore/actions/workflows/build.yml)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/GovUk.Frontend.AspNetCore)](https://www.nuget.org/packages/GovUk.Frontend.AspNetCore)
 

--- a/docs/components/service-navigation.md
+++ b/docs/components/service-navigation.md
@@ -111,3 +111,7 @@ The content is the HTML at the end of the service header container.
 
 Must be inside a `<govuk-service-navigation>` element.
 
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `align` | `GovUk.Frontend.AspNetCore.ServiceNavigationEndSlotAlign?` | How the content is aligned within the service header container. By default the content is displayed underneath the navigation items. |
+

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.ServiceNavigation.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.ServiceNavigation.cs
@@ -12,6 +12,8 @@ internal partial class DefaultComponentGenerator
         var menuButtonText = options.MenuButtonText
             .WithEmptyFallback(LocalizedText(GovUkFrontendResourceNames.ServiceNavigationMenuButtonText) ?? "Menu");
         var navigationId = options.NavigationId.WithEmptyFallback("navigation");
+        var endSlotHtml = options.Slots?.End?.Html;
+        var endSlotIsInline = options.Slots?.End?.Align == "inline";
 
         var innerContent = CreateInnerContent();
 
@@ -22,7 +24,9 @@ internal partial class DefaultComponentGenerator
         HtmlTag CreateInnerContent()
         {
             var widthContainerTag = new HtmlTag("div", attrs => attrs
-                .WithClasses("govuk-width-container"));
+                .WithClasses(
+                    "govuk-width-container",
+                    endSlotIsInline ? "govuk-service-navigation__inlining-container" : null));
 
             if (!(options.Slots?.Start).IsEmpty())
             {
@@ -72,9 +76,9 @@ internal partial class DefaultComponentGenerator
 
             widthContainerTag.InnerHtml.AppendHtml(serviceNavigationContainer);
 
-            if (!(options.Slots?.End).IsEmpty())
+            if (!endSlotHtml.IsEmpty())
             {
-                widthContainerTag.InnerHtml.AppendHtml(options.Slots.End);
+                widthContainerTag.InnerHtml.AppendHtml(endSlotHtml);
             }
 
             return widthContainerTag;
@@ -215,7 +219,7 @@ internal partial class DefaultComponentGenerator
         {
             if (!options.ServiceName.IsEmpty() ||
                 !(options.Slots?.Start).IsEmpty() ||
-                !(options.Slots?.End).IsEmpty())
+                !endSlotHtml.IsEmpty())
             {
                 var ariaLabel = TemplateString.Coalesce(
                     options.AriaLabel,

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/ServiceNavigationOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/ServiceNavigationOptions.cs
@@ -38,7 +38,13 @@ public record ServiceNavigationOptionsNavigationItem
 public record ServiceNavigationOptionsSlots
 {
     public IHtmlContent? Start { get; set; }
-    public IHtmlContent? End { get; set; }
+    public ServiceNavigationOptionsEndSlot? End { get; set; }
     public IHtmlContent? NavigationStart { get; set; }
     public IHtmlContent? NavigationEnd { get; set; }
+}
+
+public record ServiceNavigationOptionsEndSlot
+{
+    public IHtmlContent? Html { get; set; }
+    public string? Align { get; set; }
 }

--- a/src/GovUk.Frontend.AspNetCore/ServiceNavigationEndSlotAlign.cs
+++ b/src/GovUk.Frontend.AspNetCore/ServiceNavigationEndSlotAlign.cs
@@ -1,0 +1,17 @@
+namespace GovUk.Frontend.AspNetCore;
+
+/// <summary>
+/// Represents how the content at the end of a GDS service navigation component is aligned.
+/// </summary>
+public enum ServiceNavigationEndSlotAlign
+{
+    /// <summary>
+    /// The content is displayed underneath the navigation items.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// The content is displayed in line with the navigation items, when there's enough space for it.
+    /// </summary>
+    Inline = 1
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationContext.cs
@@ -6,7 +6,7 @@ internal class ServiceNavigationContext
 {
     public ServiceNavigationNavContext? Nav { get; set; }
     public (IHtmlContent Html, string TagName)? StartSlot { get; set; }
-    public (IHtmlContent Html, string TagName)? EndSlot { get; set; }
+    public (IHtmlContent Html, ServiceNavigationEndSlotAlign? Align, string TagName)? EndSlot { get; set; }
 
     /// <summary>
     /// Checks that <paramref name="tagName"/> is spelled the same way as the children specified so far.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationEndTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationEndTagHelper.cs
@@ -13,7 +13,18 @@ public class ServiceNavigationEndTagHelper : TagHelper
     internal const string TagName = "govuk-service-navigation-end";
     internal const string ShortTagName = ShortTagNames.End;
 
+    private const string AlignAttributeName = "align";
+
     private static IReadOnlyCollection<string> AllTagNames => [TagName, ShortTagName];
+
+    /// <summary>
+    /// How the content is aligned within the service header container.
+    /// </summary>
+    /// <remarks>
+    /// By default the content is displayed underneath the navigation items.
+    /// </remarks>
+    [HtmlAttributeName(AlignAttributeName)]
+    public ServiceNavigationEndSlotAlign? Align { get; set; }
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -42,7 +53,7 @@ public class ServiceNavigationEndTagHelper : TagHelper
             throw ExceptionHelper.AttributesNotSupported();
         }
 
-        serviceNavigationContext.EndSlot = (content.Snapshot(), context.TagName);
+        serviceNavigationContext.EndSlot = (content.Snapshot(), Align, context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationNavTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationNavTagHelper.cs
@@ -102,7 +102,7 @@ public class ServiceNavigationNavTagHelper : TagHelper
             throw ExceptionHelper.OnlyOneElementIsPermittedIn(AllTagNames, [ServiceNavigationTagHelper.TagName]);
         }
 
-        if (serviceNavigationContext.EndSlot is var (_, endSlotTagName))
+        if (serviceNavigationContext.EndSlot is { TagName: var endSlotTagName })
         {
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(context.TagName, endSlotTagName);
         }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationStartTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationStartTagHelper.cs
@@ -35,7 +35,7 @@ public class ServiceNavigationStartTagHelper : TagHelper
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(context.TagName, serviceNavigationContext.Nav.TagName!);
         }
 
-        if (serviceNavigationContext.EndSlot is var (_, endTagName))
+        if (serviceNavigationContext.EndSlot is { TagName: var endTagName })
         {
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(context.TagName, endTagName);
         }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ServiceNavigationTagHelper.cs
@@ -86,7 +86,17 @@ public class ServiceNavigationTagHelper : TagHelper
             Slots = new ServiceNavigationOptionsSlots
             {
                 Start = serviceNavigationContext.StartSlot?.Html,
-                End = serviceNavigationContext.EndSlot?.Html,
+                End = serviceNavigationContext.EndSlot is { } endSlot
+                    ? new ServiceNavigationOptionsEndSlot
+                    {
+                        Html = endSlot.Html,
+                        Align = endSlot.Align switch
+                        {
+                            ServiceNavigationEndSlotAlign.Inline => "inline",
+                            _ => null
+                        }
+                    }
+                    : null,
                 NavigationStart = serviceNavigationContext.Nav?.NavigationStartSlot?.Html,
                 NavigationEnd = serviceNavigationContext.Nav?.NavigationEndSlot?.Html
             },

--- a/src/GovUk.Frontend.AspNetCore/govuk-frontend.scss
+++ b/src/GovUk.Frontend.AspNetCore/govuk-frontend.scss
@@ -1,6 +1,6 @@
 @use "sass:meta";
 @use "Package/content/support" as support;
-@use "../../lib/govuk-frontend-6.4.0/dist/govuk" as * with (
+@use "../../lib/govuk-frontend-6.5.0/dist/govuk" as * with (
   $govuk-font-url-function: meta.get-function("versioned-font-url", $module: "support"),
   $govuk-image-url-function: meta.get-function("versioned-image-url", $module: "support")
 );

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ComponentFixtureData.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ComponentFixtureData.cs
@@ -25,6 +25,7 @@ public class ComponentFixtureData(
         _serializerOptions.Converters.Add(new AttributeCollectionJsonConverter());
         _serializerOptions.Converters.Add(new TemplateStringJsonConverter());
         _serializerOptions.Converters.Add(new TableOptionsRowJsonConverter());
+        _serializerOptions.Converters.Add(new ServiceNavigationOptionsEndSlotJsonConverter());
 
     }
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ServiceNavigationOptionsEndSlotJsonConverter.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ServiceNavigationOptionsEndSlotJsonConverter.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GovUk.Frontend.AspNetCore.ComponentGeneration;
+using Microsoft.AspNetCore.Html;
+
+namespace GovUk.Frontend.AspNetCore.Tests.ComponentGeneration;
+
+/// <summary>
+/// Reads the service navigation's end slot from the reference fixtures, where the slot is either
+/// the HTML to insert or an object carrying that HTML alongside its alignment;
+/// <see cref="ServiceNavigationOptionsEndSlot"/> is always the object.
+/// </summary>
+public class ServiceNavigationOptionsEndSlotJsonConverter : JsonConverter<ServiceNavigationOptionsEndSlot>
+{
+    public override ServiceNavigationOptionsEndSlot? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var element = document.RootElement;
+
+        if (element.ValueKind is JsonValueKind.String)
+        {
+            return new ServiceNavigationOptionsEndSlot { Html = new HtmlString(element.GetString()) };
+        }
+
+        return new ServiceNavigationOptionsEndSlot
+        {
+            Html = element.TryGetProperty("html", out var html) ? new HtmlString(html.GetString()) : null,
+            Align = element.TryGetProperty("align", out var align) ? align.GetString() : null
+        };
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        ServiceNavigationOptionsEndSlot value,
+        JsonSerializerOptions options)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationEndTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationEndTagHelperTests.cs
@@ -33,6 +33,37 @@ public class ServiceNavigationEndTagHelperTests : TagHelperTestBase<ServiceNavig
 
         // Assert
         Assert.Equal(content, serviceNavigationContext.EndSlot?.Html.ToHtmlString());
+        Assert.Null(serviceNavigationContext.EndSlot?.Align);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithAlign_SetsAlignOnContext()
+    {
+        // Arrange
+        var serviceNavigationContext = new ServiceNavigationContext();
+
+        var context = CreateTagHelperContext(contexts: serviceNavigationContext);
+
+        var output = CreateTagHelperOutput(
+            getChildContentAsync: (useCachedResult, encoder) =>
+            {
+                TagHelperContent tagHelperContent = new DefaultTagHelperContent();
+                tagHelperContent.SetContent("Content");
+                return Task.FromResult(tagHelperContent);
+            });
+
+        var tagHelper = new ServiceNavigationEndTagHelper()
+        {
+            Align = ServiceNavigationEndSlotAlign.Inline
+        };
+
+        tagHelper.Init(context);
+
+        // Act
+        await tagHelper.ProcessAsync(context, output);
+
+        // Assert
+        Assert.Equal(ServiceNavigationEndSlotAlign.Inline, serviceNavigationContext.EndSlot?.Align);
     }
 
     [Fact]
@@ -43,7 +74,7 @@ public class ServiceNavigationEndTagHelperTests : TagHelperTestBase<ServiceNavig
 
         var serviceNavigationContext = new ServiceNavigationContext
         {
-            EndSlot = new(new TemplateString("Existing end slot"), TagName)
+            EndSlot = new(new TemplateString("Existing end slot"), null, TagName)
         };
 
         var context = CreateTagHelperContext(contexts: serviceNavigationContext);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationNavTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationNavTagHelperTests.cs
@@ -110,7 +110,7 @@ public class ServiceNavigationNavTagHelperTests : TagHelperTestBase<ServiceNavig
 
         var serviceNavigationContext = new ServiceNavigationContext
         {
-            EndSlot = new(new TemplateString("End slot"), endTagName)
+            EndSlot = new(new TemplateString("End slot"), null, endTagName)
         };
 
         var context = CreateTagHelperContext(contexts: serviceNavigationContext);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationStartTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationStartTagHelperTests.cs
@@ -117,7 +117,7 @@ public class ServiceNavigationStartTagHelperTests : TagHelperTestBase<ServiceNav
 
         var serviceNavigationContext = new ServiceNavigationContext
         {
-            EndSlot = new(new TemplateString("End slot"), endTagName)
+            EndSlot = new(new TemplateString("End slot"), null, endTagName)
         };
 
         var context = CreateTagHelperContext(contexts: serviceNavigationContext);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ServiceNavigationTagHelperTests.cs
@@ -60,7 +60,7 @@ public class ServiceNavigationTagHelperTests : TagHelperTestBase<ServiceNavigati
 
                 serviceNavigationContext.Nav.Items.Add(item);
 
-                serviceNavigationContext.EndSlot = new(new TemplateString(endSlotContent), ServiceNavigationEndTagHelper.TagName);
+                serviceNavigationContext.EndSlot = new(new TemplateString(endSlotContent), ServiceNavigationEndSlotAlign.Inline, ServiceNavigationEndTagHelper.TagName);
 
                 TagHelperContent content = new DefaultTagHelperContent();
                 return Task.FromResult(content);
@@ -93,7 +93,8 @@ public class ServiceNavigationTagHelperTests : TagHelperTestBase<ServiceNavigati
         Assert.Equal(navigationClassName, actualOptions.NavigationClasses);
         AssertContainsAttributes(navigationAttributes, actualOptions.NavigationAttributes);
         Assert.Equal(startSlotContent, actualOptions.Slots?.Start?.ToHtmlString());
-        Assert.Equal(endSlotContent, actualOptions.Slots?.End?.ToHtmlString());
+        Assert.Equal(endSlotContent, actualOptions.Slots?.End?.Html?.ToHtmlString());
+        Assert.Equal("inline", actualOptions.Slots?.End?.Align);
         Assert.Equal(navStartSlotContent, actualOptions.Slots?.NavigationStart?.ToHtmlString());
         Assert.Equal(navEndSlotContent, actualOptions.Slots?.NavigationEnd?.ToHtmlString());
         Assert.NotNull(actualOptions.Navigation);


### PR DESCRIPTION
Bumps `GovUkFrontendVersion` to 6.5.0.

The only component whose markup changed for inputs the library can express is the service navigation, whose `end` slot now takes an alignment alongside its content, so that content such as a language navigation can sit in line with the navigation items rather than underneath them.

- `ServiceNavigationOptionsSlots.End` is now a `ServiceNavigationOptionsEndSlot`, carrying the slot's `Html` and its `Align`, mirroring the reference template's string-or-object parameter. The fixtures deserialize both shapes through a converter, as the table's rows already do.
- The width container gains `govuk-service-navigation__inlining-container` when the slot is aligned `inline`, and the containing `<section>` is now chosen by the slot's content rather than by the slot itself.
- `<govuk-service-navigation-end>` has an `align` attribute for it.

The language navigation and feedback components introduced in 6.5.0 are new components rather than markup changes; their tag helpers follow in a separate PR.

### Breaking change

`ServiceNavigationOptionsSlots.End` is a `ServiceNavigationOptionsEndSlot?` rather than an `IHtmlContent?`:

```diff
-End = content
+End = new ServiceNavigationOptionsEndSlot { Html = content }
```

The tag helpers are unaffected.

### Verification

`just test` — unit (5922), integration (354) and package (49) tests all pass across net8.0/net9.0/net10.0. Docs regenerated for the new `align` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
