### PR TITLE
Run the build on pull requests based on any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,10 @@ on:
       - LICENSE
       - "**.md"
   pull_request:
+    # ** so that a pull request based on another branch, whose name contains a
+    # slash, is matched too; * stops at the slash
     branches:
-      - "*"
+      - "**"
     paths-ignore:
       - docs/**
       - LICENSE


### PR DESCRIPTION
The `pull_request` trigger filtered its **base** branch on `"*"`. That pattern matches any character except a slash, so a pull request stacked on another branch — any `claude/…` or `dependabot/…` name — matched nothing and got no checks at all until it was retargeted at `main`. `"**"` matches the slash too.

The `push` trigger is unchanged: that one names `main` and `dev` deliberately.

Nothing else is affected by the wider filter. The publish job is gated on `startsWith(github.ref, 'refs/tags/v')`, so it stays skipped on pull requests as before.

This came up on https://github.com/x-govuk/govuk-frontend-aspnetcore/pull/570, which is stacked on https://github.com/x-govuk/govuk-frontend-aspnetcore/pull/569 and so currently runs no checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
